### PR TITLE
Bugfix unique_fragColor positioning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var version = require('glsl-version-regex')
 var inject = require('glsl-token-inject-block')
 var tokenize = require('glsl-tokenizer')
 var stringify = require('glsl-token-string')
@@ -7,6 +6,8 @@ module.exports.vertex = transpile.bind(null, true)
 module.exports.fragment = transpile.bind(null, false)
 module.exports.mapName = mapName
 module.exports.unmapName = unmapName
+
+var version = /^\s*\#version\s+([0-9]+(\s+[a-zA-Z]+)?)\s*/
 
 const coreGLSLExtensions = [
   'GL_OES_standard_derivatives',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var inject = require('glsl-token-inject-block')
 var tokenize = require('glsl-tokenizer')
 var stringify = require('glsl-token-string')
 
@@ -8,6 +7,8 @@ module.exports.mapName = mapName
 module.exports.unmapName = unmapName
 
 var version = /^\s*\#version\s+([0-9]+(\s+[a-zA-Z]+)?)\s*/
+var regex = /[^\r\n]$/
+var newline = { data: '\n', type: 'whitespace' }
 
 const coreGLSLExtensions = [
   'GL_OES_standard_derivatives',
@@ -175,4 +176,50 @@ function unmapName(name) {
     name = match[1];
   }
   return name;
+}
+
+function inject(tokens, newTokens) {
+  if (!Array.isArray(newTokens))
+    newTokens = [ newTokens ]
+  var start = getStartIndex(tokens)
+  var last = start > 0 ? tokens[start-1] : null
+  if (last && regex.test(last.data)) {
+    tokens.splice(start++, 0, newline)
+  }
+  tokens.splice.apply(tokens, [ start, 0 ].concat(newTokens))
+  
+  var end = start + newTokens.length
+  if (tokens[end] && /[^\r\n]$/.test(tokens[end].data)) {
+    tokens.splice(end, 0, newline)
+  }
+  return tokens
+}
+
+function getStartIndex(tokens) {
+  // determine starting index for attributes
+  var start = -1
+  for (var i = 0; i < tokens.length; i++) {
+    var token = tokens[i]
+    if (token.type === 'preprocessor') {
+      if (/^#(extension|version|endif)/.test(token.data)) {
+        start = Math.max(start, i)
+      }
+    } else if (token.type === 'keyword' && token.data === 'precision') {
+      var semi = findNextSemicolon(tokens, i)
+      if (semi === -1) {
+        throw new Error('precision statement not followed by any semicolons!')
+      }
+      start = Math.max(start, semi)
+    }
+  }
+  return start + 1
+}
+
+function findNextSemicolon(tokens, start) {
+  for (var i = start; i < tokens.length; i++) {
+    if (tokens[i].type === 'operator' && tokens[i].data === ';') {
+      return i
+    }
+  }
+  return -1
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "email": "a@modules.io"
   },
   "dependencies": {
-    "glsl-token-inject-block": "^1.1.0",
     "glsl-token-string": "^1.0.1",
     "glsl-tokenizer": "^2.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "glsl-token-inject-block": "^1.1.0",
     "glsl-token-string": "^1.0.1",
-    "glsl-tokenizer": "^2.1.2",
-    "glsl-version-regex": "^1.0.0"
+    "glsl-tokenizer": "^2.1.2"
   },
   "devDependencies": {
     "faucet": "0.0.1",


### PR DESCRIPTION
Fixes https://github.com/webmixedreality/exokit/issues/493

The bug was that this shader:

```
#version 100
#extension GL_EXT_shader_texture_lod : require
#ifdef GL_FRAGMENT_PRECISION_HIGH
  precision highp float;
#else
 precision mediump float;
#endif
uniform samplerCube uT0;
varying vec3 vC;
void main(void) {
  gl_FragColor = textureCubeLodEXT(uT0, vC, 1.0);
}
```

would compile to

```
#version 150
#extension GL_ARB_separate_shader_objects : enable

#ifdef GL_FRAGMENT_PRECISION_HIGH
  precision highp float;
#else
 precision mediump float;
out vec4 unique_fragColor;
#endif
uniform samplerCube uT0;
in vec3 vC;
void main(void) {
  unique_fragColor = textureLod(uT0, vC, 1.0);
}
```

Note the misplaced `out vec4 unique_fragColor;`. The root bug was this regex not accounting for directives (`#if`): https://github.com/Jam3/glsl-token-inject-block/blob/1d5c57154cbe6a98a9f1094b7496e5c79414c2d7/index.js#L29

This is to inline that module here and change the regex to `/^#(extension|version|endif)/`